### PR TITLE
Fix race condition in serial write part

### DIFF
--- a/src/velbustcp/lib/connection/serial/bus.py
+++ b/src/velbustcp/lib/connection/serial/bus.py
@@ -120,6 +120,8 @@ class Bus():
         self.__writer = WriterThread(serial_port)
         self.__writer.start()
 
+        self.__serial_port = serial_port 
+
         self.__logger.info("Serial connection active on port %s", self.__port)
 
     def stop(self) -> None:
@@ -140,6 +142,9 @@ class Bus():
 
         if self.__writer and self.__writer.alive:
             self.__writer.close()
+
+        if self.__serial_port.isOpen():
+            self.__serial_port.close()
 
     def send(self, packet: bytearray) -> None:
         """Queues a packet to be sent on the serial connection.

--- a/src/velbustcp/lib/connection/serial/bus.py
+++ b/src/velbustcp/lib/connection/serial/bus.py
@@ -144,6 +144,8 @@ class Bus():
             self.__writer.close()
 
         if self.__serial_port.isOpen():
+            self.__serial_port.cancel_read()
+            self.__serial_port.cancel_write()
             self.__serial_port.close()
 
     def send(self, packet: bytearray) -> None:

--- a/src/velbustcp/lib/connection/serial/bus.py
+++ b/src/velbustcp/lib/connection/serial/bus.py
@@ -120,7 +120,7 @@ class Bus():
         self.__writer = WriterThread(serial_port)
         self.__writer.start()
 
-        self.__serial_port = serial_port 
+        self.__serial_port = serial_port
 
         self.__logger.info("Serial connection active on port %s", self.__port)
 

--- a/src/velbustcp/lib/connection/serial/writerthread.py
+++ b/src/velbustcp/lib/connection/serial/writerthread.py
@@ -52,7 +52,7 @@ class WriterThread(threading.Thread):
 
         last_send_time = time.monotonic()
         self.alive: bool = True
-        
+
         while self.alive and self.__serial.is_open:
             self.__send_event.wait()
             self.__send_event.clear()

--- a/src/velbustcp/lib/connection/serial/writerthread.py
+++ b/src/velbustcp/lib/connection/serial/writerthread.py
@@ -51,7 +51,7 @@ class WriterThread(threading.Thread):
         """
 
         last_send_time = time.monotonic()
-        self.alive: bool = True
+        self.alive = True
 
         while self.alive and self.__serial.is_open:
             self.__send_event.wait()

--- a/src/velbustcp/lib/connection/serial/writerthread.py
+++ b/src/velbustcp/lib/connection/serial/writerthread.py
@@ -12,7 +12,7 @@ from velbustcp.lib.signals import on_bus_send
 class WriterThread(threading.Thread):
 
     def __init__(self, serial_instance: Serial):
-        self.alive: bool = True
+        self.alive: bool = False
         self.__serial: Serial = serial_instance
         self.__logger = logging.getLogger("__main__." + __name__)
         self.__send_event: threading.Event = threading.Event()
@@ -51,7 +51,8 @@ class WriterThread(threading.Thread):
         """
 
         last_send_time = time.monotonic()
-
+        self.alive: bool = True
+        
         while self.alive and self.__serial.is_open:
             self.__send_event.wait()
             self.__send_event.clear()


### PR DESCRIPTION
When the writing thread encounters an issue before the thread was started, it could not join with the parent thread, causing it to never be able to write messages on the bus anymore until it restarted. 